### PR TITLE
Adding support for DLX filtered live view

### DIFF
--- a/custom_components/deltasol/const.py
+++ b/custom_components/deltasol/const.py
@@ -1,7 +1,7 @@
 """ Constants for the Resol Deltasol KM2/DL2/DL3 Integration """
 import logging
 
-_LOGGER = logging.getLogger('custom_component.deltasol')
+_LOGGER = logging.getLogger('custom_components.deltasol')
 DOMAIN = "deltasol"
 DEFAULT_NAME = "Resol Deltasol KM2/DL2/DL3"
 DEFAULT_TIMEOUT = 60

--- a/custom_components/deltasol/deltasolapi.py
+++ b/custom_components/deltasol/deltasolapi.py
@@ -28,14 +28,17 @@ class DeltasolApi(object):
 
         data = {}
 
-        j = 0
-        for i in response["headers"][0]["fields"]:
-            value = response["headersets"][0]["packets"][0]["field_values"][j]["raw_value"]
-            if isinstance(value, float):
-              value = round(value, 2)
-            unit = i["unit"].strip()
-            data[i["name"].replace(" ", "_").lower()] = (value, icon_mapper[unit], unit)
-            j += 1
+        iHeader = 0
+        for header in response["headers"]:
+            iField = 0
+            for field in response["headers"][iHeader]["fields"]:
+                value = response["headersets"][0]["packets"][iHeader]["field_values"][iField]["raw_value"]
+                if isinstance(value, float):
+                    value = round(value, 2)
+                unit = field["unit"].strip()
+                data[field["name"].replace(" ", "_").lower()] = (value, icon_mapper[unit], unit)
+                iField += 1
+            iHeader +=1
 
         return data
 

--- a/custom_components/deltasol/deltasolapi.py
+++ b/custom_components/deltasol/deltasolapi.py
@@ -14,13 +14,13 @@ from .const import (
 class DeltasolApi(object):
     """ Wrapper class for Deltasol KM2"""
 
-    def __init__(self, username, password, host, api_mode="km2"):
+    def __init__(self, username, password, host, api_mode="km2", api_filter=""):
         self.data = None
         self.host = host
         self.username = username
         self.password = password
         self.api_mode = api_mode
-
+        self.api_filter = api_filter
 
     def __parse_data(self, response):
         icon_mapper = defaultdict(lambda: "mdi:flash")
@@ -65,7 +65,11 @@ class DeltasolApi(object):
             response = response[0]["result"]
             
         elif self.api_mode == "dlx":
-            url = f'http://{self.host}/dlx/download/live?sessionAuthUsername={self.username}&sessionAuthPassword={self.password}'
+            #API doco http://danielwippermann.github.io/resol-vbus/#/md/docs/dlx-data-download-api
+            filter = f"filter={self.api_filter}&" if self.api_filter else ""
+            
+            url = f'http://{self.host}/dlx/download/live?{filter}sessionAuthUsername={self.username}&sessionAuthPassword={self.password}'
+            _LOGGER.debug(f"Requesting sensor data {url}")
             response = requests.request("GET", url).json()
 
         return self.__parse_data(response)

--- a/custom_components/deltasol/sensor.py
+++ b/custom_components/deltasol/sensor.py
@@ -8,6 +8,7 @@ sensor:
   - platform: deltasol
     #scan_interval: 300
     #mode: km2
+    #filter: 00
     host: 192.168.178.15
     username: username
     password: password
@@ -26,6 +27,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_PASSWORD,
     CONF_MODE,
+    CONF_FILTER,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_POWER_FACTOR
 )
@@ -42,6 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_USERNAME): config_validation.string,
         vol.Required(CONF_PASSWORD): config_validation.string,
         vol.Optional(CONF_MODE, default="km2"): vol.In(["km2", "dlx"]),
+        vol.Optional(CONF_FILTER): config_validation.matches_regex("\d\d"),
     }
 )
 
@@ -49,7 +52,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Setup the Deltasol KM2 sensors."""
 
-    api = DeltasolApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD), config.get(CONF_HOST), config.get(CONF_MODE))
+    api = DeltasolApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD), config.get(CONF_HOST), config.get(CONF_MODE), config.get(CONF_FILTER))
 
     async def async_update_data():
         """ fetch data from the Resol Deltasol KM2/DL2/DL3"""


### PR DESCRIPTION
Updated to add support for the DLX filtered live view.
This is working if I hard code the filter value. However the config setup for **CONF_FILTER** is not correct. HA does not seem to accept it. it gives an error `ImportError: cannot import name 'CONF_FILTER' from 'homeassistant.const' (/usr/src/homeassistant/homeassistant/const.py)`. Any help working out why would be appreciated.

Also 
* Change the name of the logger, believe it should be **custom_components** not **custom_component**.
* Added support for extracting data from multiple headers if they exists. My DL3 has some sensors, as well as the DeltaSol. The values come on separate headers.