### PR TITLE
Multiple bus devices and id conversion

### DIFF
--- a/custom_components/deltasol/deltasolapi.py
+++ b/custom_components/deltasol/deltasolapi.py
@@ -40,7 +40,7 @@ class DeltasolApi(object):
                 if isinstance(value, float):
                     value = round(value, 2)
                 unit = field["unit"].strip()
-                data[field["name"].replace(" ", "_").lower()] = (value, icon_mapper[unit], unit)
+                data[field["name"].replace(" ", "_").lower()] = (value, icon_mapper[unit], unit, header["id"] + "__" + field["id"], header["description"], header["destination_name"], header["source_name"])
                 iField += 1
             iHeader +=1
 

--- a/custom_components/deltasol/sensor.py
+++ b/custom_components/deltasol/sensor.py
@@ -77,14 +77,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     sensor_prefix = config.get(CONF_NAME)
 
     async_add_entities(
-        DeltasolSensor(coordinator, _name, values[1], values[2]) for _name, values in coordinator.data.items()
+        DeltasolSensor(coordinator, _name, values[1], values[2], values[3], values[4], values[5], values[6]) for _name, values in coordinator.data.items()
     )
 
 
 class DeltasolSensor(SensorEntity):
     """Representation of a Resol Deltasol Sensor."""
 
-    def __init__(self, coordinator, _name, _icon, _unit):
+    def __init__(self, coordinator, _name, _icon, _unit, _unique_id, _desc, _dest_name, _src_name):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self._last_updated = None
@@ -92,6 +92,10 @@ class DeltasolSensor(SensorEntity):
         self._icon = _icon
         self._unit = _unit
         self._state = self.state
+        self._unique_id = _unique_id
+        self._desc = _desc
+        self._dest_name = _dest_name
+        self._src_name = _src_name
 
     @property
     def should_poll(self):
@@ -119,7 +123,7 @@ class DeltasolSensor(SensorEntity):
     @property
     def unique_id(self):
         """Return the unique ID of the binary sensor."""
-        return self._name
+        return self._unique_id
 
     @property
     def icon(self):
@@ -166,6 +170,9 @@ class DeltasolSensor(SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes of this device."""
         attr = {}
+        attr["description"] = self._desc
+        attr["destination_name"] = self._dest_name
+        attr["source_name"] = self._src_name
         if self._last_updated is not None:
             attr["Last Updated"] = self._last_updated
         return attr


### PR DESCRIPTION
Implements https://github.com/dm82m/hass-Deltasol-KM2/issues/10 with my suggestions.

- Reverting filters of DLx devices
  In my opinion, we should keep the configuration as simple as possible and the code as clean as possible.
  The functionality can be achieved using Home Assistant GUI configuration, by renaming the now unique entities.
- Revised API to use a named tuple to exchange information. So you don't have to rely on int indexes to get the right field. (readability of code)
- Finally if the component finds entities with the old id, it is converted to the new one. If a new one already exists it is replaced by the old entity. (Should only be the case for @dm82m and me, as we tested the new ids before we had a conversion)

Already rebased on https://github.com/dm82m/hass-Deltasol-KM2/pull/15. So we should merge that first.

Happy to hear your opinions, especially about the drop of filtering...