### PR TITLE
energy device class support

### DIFF
--- a/custom_components/deltasol/sensor.py
+++ b/custom_components/deltasol/sensor.py
@@ -110,7 +110,8 @@ class DeltasolSensor(SensorEntity):
         'l/h': 'mdi:hydro-power',
         'bar': 'mdi:car-brake-low-pressure',
         '%RH': 'mdi:water-percent',
-        's': 'mdi:timer' })
+        's': 'mdi:timer',
+        'Wh': 'mdi:solar-power-variant-outline'})
 
     def __init__(self, coordinator, unique_id, endpoint):
         """ Initialize the sensor. """
@@ -183,6 +184,8 @@ class DeltasolSensor(SensorEntity):
             return SensorDeviceClass.TEMPERATURE
         elif self._unit == '%':
             return SensorDeviceClass.POWER_FACTOR
+        elif self._unit == 'Wh':
+            return SensorDeviceClass.ENERGY
         else:
             return None
 
@@ -191,6 +194,8 @@ class DeltasolSensor(SensorEntity):
         """ Return the state class of this entity, if any. """
         if self._unit == '°C':
             return SensorStateClass.MEASUREMENT
+        elif self._unit == 'Wh':
+            return SensorStateClass.TOTAL_INCREASING
         else:
             return None
 


### PR DESCRIPTION
for solar heat meters reporting their energy gain in Wh, an appropriate symbol as well as device and state classes are added 
these entities can now be integrated in HA energy dashboard directly

![image](https://user-images.githubusercontent.com/123907612/218333272-c3399eab-6d91-4e7b-8ff2-ed0b765c3084.png)
